### PR TITLE
Fix fragmentation example data size

### DIFF
--- a/compressor.c
+++ b/compressor.c
@@ -103,7 +103,7 @@ struct schc_rule_t* get_schc_rule_by_reliability_mode(
 
 	if (device == NULL) {
 		DEBUG_PRINTF(
-				"get_schc_rule(): no device was found for this id");
+				"get_schc_rule(): no device was found for the id: %d\n", device_id);
 		return NULL;
 	}
 

--- a/examples/fragment.c
+++ b/examples/fragment.c
@@ -21,7 +21,7 @@
 
 #include "timer.h"
 
-#define PACKET_LENGTH			204
+#define PACKET_LENGTH			251
 #define MAX_PACKET_LENGTH		128
 #define MAX_TIMERS				256
 


### PR DESCRIPTION
Hi,

There was an issue with fragmentation data size.

Why not using the following declaration then `sizeof(msg)` when size is required ?
```
uint8_t msg[] = {
		// IPv6 header
		// IPv6 header
		0x60, 0x00, 0x00, 0x00, 0x00, 0x1E, 0x11, 0x40, 0xAA, 0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
		0x60, 0x00, 0x00, 0x00, 0x00, 0x1E, 0x11, 0x40, 0xAA, 0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ..............................
}
```

I also slightly changed a debug message to improve it