### PR TITLE
fragmenter: aim for more object-oriented approach for callbacks

### DIFF
--- a/examples/fragment.c
+++ b/examples/fragment.c
@@ -28,8 +28,8 @@ int RUN = 1;
 int counter = 1;
 
 struct cb_t {
-    schc_fragmentation_t* conn;
-    void (*cb)(schc_fragmentation_t* conn);
+    void* arg;
+    void (*cb)(void* arg);
     struct cb_t *next;
 };
 
@@ -94,7 +94,7 @@ void cleanup() {
 /*
  * Callback to handle the end of a fragmentation sequence
  */
-void end_tx() {
+void end_tx(schc_fragmentation_t *conn) {
 	DEBUG_PRINTF("end_tx() callback \n");
 }
 
@@ -133,7 +133,7 @@ void timer_handler(size_t timer_id, void* user_data) {
 	stop_timer(timer_id);
 
 	struct cb_t* cb_t_ = (struct cb_t*) user_data;
-	schc_fragmentation_t* conn = cb_t_->conn;
+	schc_fragmentation_t* conn = cb_t_->arg;
 
 	cb_t_->cb(conn);
 }
@@ -141,14 +141,14 @@ void timer_handler(size_t timer_id, void* user_data) {
 /*
  * The timer used by the SCHC library to schedule the transmission of fragments
  */
-static void set_tx_timer(void (*callback)(schc_fragmentation_t* conn),
-		uint32_t device_id, uint32_t delay, void *arg) {
+static void set_tx_timer(schc_fragmentation_t *conn, void (*callback)(void* arg),
+		uint32_t delay, void *arg) {
 	counter++;
 
 	uint16_t delay_sec = delay / 1000;
 
 	struct cb_t* cb_t_= malloc(sizeof(struct cb_t)); // create on heap
-	cb_t_->conn = arg;
+	cb_t_->arg = arg;
 	cb_t_->cb = callback;
 
 	struct cb_t* curr = head;
@@ -177,12 +177,12 @@ static void set_tx_timer(void (*callback)(schc_fragmentation_t* conn),
  * The timer used by the SCHC library to time out the reception of fragments
  * should have multiple timers for a device
  */
-static void set_rx_timer(void (*callback)(schc_fragmentation_t* conn),
-		uint32_t device_id, uint32_t delay, void *arg) {
+static void set_rx_timer(schc_fragmentation_t *conn, void (*callback)(void* arg),
+		uint32_t delay, void *arg) {
 	uint16_t delay_sec = delay / 1000;
 
 	struct cb_t* cb_t_= malloc(sizeof(struct cb_t)); // create on heap
-	cb_t_->conn = arg;
+	cb_t_->arg = arg;
 	cb_t_->cb = callback;
 
 	struct cb_t* curr = head;
@@ -209,8 +209,8 @@ static void set_rx_timer(void (*callback)(schc_fragmentation_t* conn),
  * Callback to remove a timer entry for a device
  * (required by some timer libraries)
  */
-void remove_timer_entry(uint32_t device_id) {
-	DEBUG_PRINTF("remove_timer_entry(): remove timer entry for device with id %d \n", device_id);
+void remove_timer_entry(schc_fragmentation_t *conn) {
+	DEBUG_PRINTF("remove_timer_entry(): remove timer entry for device with id %d \n", conn->device_id);
 }
 
 void received_packet(uint8_t* data, uint16_t length, uint32_t device_id, schc_fragmentation_t* receiving_conn) {

--- a/fragmenter.c
+++ b/fragmenter.c
@@ -689,6 +689,9 @@ static int8_t init_tx_connection(schc_fragmentation_t* conn) {
  */
 void schc_reset(schc_fragmentation_t* conn) {
 	/* reset connection variables */
+	if (conn->remove_timer_entry) {
+		conn->remove_timer_entry(conn);
+	}
 	conn->device_id = 0;
 	conn->tail_ptr = 0;
 	conn->dc = 0;
@@ -703,6 +706,7 @@ void schc_reset(schc_fragmentation_t* conn) {
 	conn->RX_STATE = RECV_WINDOW;
 	conn->window = 0;
 	conn->window_cnt = 0;
+	conn->timer_ctx = NULL;
 	conn->timer_flag = 0;
 	conn->input = 0;
 	memset(conn->mic, 0, MIC_SIZE_BYTES);
@@ -931,9 +935,26 @@ static void discard_fragment(schc_fragmentation_t* conn) {
 static void abort_connection(schc_fragmentation_t* conn) {
 	// todo
 	DEBUG_PRINTF("abort_connection(): inactivity timer expired \n");
-	conn->remove_timer_entry(conn->device_id);
 	schc_reset(conn);
 	return;
+}
+
+/**
+ * callback for schc_fragmentation_t::post_timer_task to time schc_fragment
+ *
+ * @param   arg The argument for the callback
+ */
+static void schc_fragment_timer_cb(void *arg) {
+	schc_fragment(arg);
+}
+
+/**
+ * callback for schc_fragmentation_t::post_timer_task to time schc_reassemble
+ *
+ * @param   arg The argument for the callback
+ */
+static void schc_reassemble_timer_cb(void *arg) {
+	schc_reassemble(arg);
 }
 
 /**
@@ -946,7 +967,7 @@ static void abort_connection(schc_fragmentation_t* conn) {
 static void set_retrans_timer(schc_fragmentation_t* conn) {
 	conn->timer_flag = 1;
 	DEBUG_PRINTF("set_retrans_timer(): for %d ms \n", (int) (conn->dc * 4));
-	conn->post_timer_task( (*schc_fragment), conn->device_id, conn->dc * 4, conn);
+	conn->post_timer_task(conn, schc_fragment_timer_cb, conn->dc * 4, conn);
 }
 
 /**
@@ -957,7 +978,7 @@ static void set_retrans_timer(schc_fragmentation_t* conn) {
  */
 static void set_dc_timer(schc_fragmentation_t* conn) {
 	DEBUG_PRINTF("set_dc_timer(): for %d ms \n", (int) conn->dc);
-	conn->post_timer_task( (*schc_fragment), conn->device_id, conn->dc, conn);
+	conn->post_timer_task(conn, schc_fragment_timer_cb, conn->dc, conn);
 }
 
 /**
@@ -970,7 +991,7 @@ static void set_dc_timer(schc_fragmentation_t* conn) {
 static void set_inactivity_timer(schc_fragmentation_t* conn) {
 	conn->timer_flag = 1;
 	DEBUG_PRINTF("set_inactivity_timer(): for %d ms \n", (int) conn->dc);
-	conn->post_timer_task( (*schc_reassemble), conn->device_id, conn->dc, conn);
+	conn->post_timer_task(conn, schc_reassemble_timer_cb, conn->dc, conn);
 }
 
 /**
@@ -1362,6 +1383,7 @@ int8_t schc_reassemble(schc_fragmentation_t* rx_conn) {
 	tail->frag_cnt = rx_conn->frag_cnt; // update tail frag count
 
 	if(rx_conn->input) { // set inactivity timer if the loop was triggered by a fragment input
+		rx_conn->remove_timer_entry(rx_conn); // remove previously set inactivity timer
 		set_inactivity_timer(rx_conn);
 	}
 
@@ -1700,7 +1722,7 @@ int8_t schc_reassemble(schc_fragmentation_t* rx_conn) {
 int8_t schc_fragmenter_init(schc_fragmentation_t* tx_conn,
 		uint8_t (*send)(uint8_t* data, uint16_t length, uint32_t device_id),
 		void (*end_rx)(schc_fragmentation_t* conn),
-		void (*remove_timer_entry)(uint32_t device_id)) {
+		void (*remove_timer_entry)(schc_fragmentation_t *conn)) {
 	uint32_t i;
 
 	// initializes the schc tx connection
@@ -1884,7 +1906,7 @@ int8_t schc_fragment(schc_fragmentation_t *tx_conn) {
 	if (tx_conn->TX_STATE == END_TX) {
 		DEBUG_PRINTF("schc_fragment(): end transmission cycle\n");
 		tx_conn->timer_flag = 0;
-		tx_conn->end_tx();
+		tx_conn->end_tx(tx_conn);
 		schc_reset(tx_conn); // todo ??
 		return SCHC_END;
 	}
@@ -2001,7 +2023,7 @@ int8_t schc_fragment(schc_fragmentation_t *tx_conn) {
 		}
 		case END_TX: {
 			DEBUG_PRINTF("schc_fragment(): end transmission cycle\n");
-			tx_conn->end_tx();
+			tx_conn->end_tx(tx_conn);
 			schc_reset(tx_conn);
 			return SCHC_END;
 			break;

--- a/fragmenter.h
+++ b/fragmenter.h
@@ -125,14 +125,16 @@ typedef struct schc_fragmentation_t {
 	/* the function to call when the fragmenter has something to send */
 	uint8_t (*send)(uint8_t* data, uint16_t length, uint32_t device_id);
 	/* the timer task */
-	void (*post_timer_task)(int8_t (*timer_task)(struct schc_fragmentation_t* conn), uint32_t device_id,
-			uint32_t time_ms, void *arg);
+	void (*post_timer_task)(struct schc_fragmentation_t *conn,
+			void (*timer_task)(void* arg), uint32_t time_ms, void *arg);
 	/* this function is called when the last rx timer expires */
 	void (*end_rx)(struct schc_fragmentation_t *conn);
 	/* this function is called once the device reaches the END_TX state */
-	void (*end_tx)(void);
+	void (*end_tx)(struct schc_fragmentation_t *conn);
 	/* this callback may be used to remove a timer entry */
-	void (*remove_timer_entry)(uint32_t device_id);
+	void (*remove_timer_entry)(struct schc_fragmentation_t *conn);
+	/* timer context for the application */
+	void *timer_ctx;
 	/* indicates whether a timer has expired */
 	uint8_t timer_flag;
 	/* indicates if a fragment is received or this is a callback */
@@ -152,7 +154,7 @@ typedef struct schc_fragmentation_t {
 int8_t schc_fragmenter_init(schc_fragmentation_t* tx_conn,
 		uint8_t (*send)(uint8_t* data, uint16_t length, uint32_t device_id),
 		void (*end_rx)(schc_fragmentation_t* conn),
-		void (*remove_timer_entry)(uint32_t device_id));
+		void (*remove_timer_entry)(schc_fragmentation_t* conn));
 int8_t schc_fragment(schc_fragmentation_t *tx_conn);
 int8_t schc_reassemble(schc_fragmentation_t* rx_conn);
 void schc_reset(schc_fragmentation_t* conn);


### PR DESCRIPTION
This makes it easier for an application to manage the timers.

Both the `fragment` and `interop` example segfault, but this is also the case in the `master` branch, as in the respective `cleanup` functions it is not checked, if `curr` is NULL.