### PR TITLE
compressor.c: per-device definition of uncompressed rule

### DIFF
--- a/compressor.h
+++ b/compressor.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-int8_t set_rule_id(struct schc_compression_rule_t* schc_rule, uint8_t* data);
+int8_t set_rule_id(struct schc_compression_rule_t* schc_rule, uint32_t device_id, uint8_t* data);
 
 uint8_t schc_compressor_init();
 struct schc_compression_rule_t* schc_compress(uint8_t *data, uint16_t total_length,

--- a/rules/rules_example.h
+++ b/rules/rules_example.h
@@ -286,8 +286,8 @@ const struct schc_fragmentation_rule_t* node1_fragmentation_rules[] = {
 };
 
 /* now build the context for a particular device */
-const struct schc_device node1 = { 0x06, 4, &node1_compression_rules, 4, &node1_fragmentation_rules };
-const struct schc_device node2 = { 0x01, 4, &node1_compression_rules, 4, &node1_fragmentation_rules };
+const struct schc_device node1 = { 0x06, 0, 4, &node1_compression_rules, 4, &node1_fragmentation_rules };
+const struct schc_device node2 = { 0x01, 0, 4, &node1_compression_rules, 4, &node1_fragmentation_rules };
 
 #define DEVICE_COUNT			2
 

--- a/schc.h
+++ b/schc.h
@@ -232,6 +232,7 @@ struct schc_fragmentation_rule_t {
 struct schc_device {
 	/* the device id (e.g. EUI) */
 	uint32_t device_id;
+	uint32_t uncomp_rule_id;
 	/* the total number of compression rules for a device */
 	uint8_t compression_rule_count;
 	/* a pointer to the collection of compression rules for a device */


### PR DESCRIPTION
Currently the library does not build, since `UNCOMPRESSED_ID` is not available in compressor.c. With this the rule ID for uncompressed packets is defined per device and taken from that.