### PR TITLE
compressor: do not continue compression if rule ID can not be set

### DIFF
--- a/compressor.c
+++ b/compressor.c
@@ -829,7 +829,9 @@ struct schc_compression_rule_t* schc_compress(uint8_t *data, uint16_t total_leng
 	schc_rule = get_schc_rule_by_layer_ids(ipv6_rule_id,
 			udp_rule_id, coap_rule_id, device_id);
 
-	set_rule_id(schc_rule, device_id, dst->ptr);
+	if (set_rule_id(schc_rule, device_id, dst->ptr) != 1) {
+		return NULL;
+	}
 	dst->offset = RULE_SIZE_BITS;
 
 	if(schc_rule == NULL) {


### PR DESCRIPTION
As a consequence of #25 there is now a case, where the compression rule can not be set in the SCHC layer (when the device provided does not exist in this case). However, I failed to add a check for that in `schc_compress()`, leading to all uncompressed packets for a wrong device to default to rule ID 0 (or whatever garbage was in the output buffer before). This fixes that by just not doing compression in case the rule ID was not set.