### PR TITLE
compressor: fix uninitialized variable error

### DIFF
--- a/compressor.c
+++ b/compressor.c
@@ -776,7 +776,9 @@ struct schc_compression_rule_t* schc_compress(uint8_t *data, uint16_t total_leng
 	DEBUG_PRINTF("schc_compress(): \n");
 
 	/* look for a matching rule */
-	struct schc_layer_rule_t *ipv6_rule; struct schc_layer_rule_t *udp_rule; struct schc_layer_rule_t *coap_rule;
+	struct schc_layer_rule_t *ipv6_rule = NULL;
+	struct schc_layer_rule_t *udp_rule = NULL;
+	struct schc_layer_rule_t *coap_rule = NULL;
 #if USE_IP6 == 1
 	ipv6_rule = schc_find_rule_from_header(&src, device, SCHC_IPV6, dir);
 	if(ipv6_rule != NULL) {


### PR DESCRIPTION
When compiling without CoAP with GCC 12.2.0, one get's a warning that `coap_rule` may be used uninitialized `get_schc_rule_by_layer_ids()`. Same for `udp_rule`, as it is only initialized when `use_udp` is set. Since `ipv6_rule` initialization is dependent on `USE_IPV6` as well, one would probably get a similar warning, when `USE_IPV6` is 0. As such, initialize all rules with NULL, so we do not accidentally initialize those pointers with some stack trash.