### PR TITLE
compressor: fix residue order

### DIFF
--- a/examples/compress.c
+++ b/examples/compress.c
@@ -78,8 +78,8 @@ int main() {
 			0xFB, /* token LSB = fb (8b) */
 #else
 			/* direction DOWN */
-			0x46, /* next header mapping index = 1 (2b), app iid LSB = 1 (4b), dev prefix mapping index = 2 (2b), */
-			0x21, /* dev iid LSB = 2 (4b), app iid LSB = 2 (4b), dev port = 0 mapping index (1b), app port mapping index = 0 (1b), type mapping index = 1 (2b) */
+			0x62, /* next header mapping index = 1 (2b), dev prefix mapping index = 2 (2b), dev iid LSB = 2 (4b), */
+			0x11, /* app iid LSB = 1 (4b), dev port mapping index = 0 (1b), app port mapping index = 0 (1b), type mapping index = 1 (2b) */
 			0xFB, /* token LSB = fb (8b) */
 #endif
 			0x01, 0x02, 0x03, 0x04 /* payload */


### PR DESCRIPTION
I made an error when implementing #31. RFC 8724, section 7.2 says:

> The Compression Residue for the packet header is the concatenation of the non-empty residues for each field of the header, **in the order the Field Descriptors appear in the Rule**. The order in which the Field Descriptors appear in the Rule is therefore semantically important.

So we do not have to reorder the rules, but the fields as they are read on compression and written on decompression. Longterm it probably makes more sense to parse the headers properly and store the offsets of each field (also helpful if there will ever be e.g. IPv6 extension header support), but as a quick fix for my blunder it should suffice (it still simplifies the code a lot again).