### PR TITLE
Fix padding in both fragmenter and compressor

### DIFF
--- a/fragmenter.c
+++ b/fragmenter.c
@@ -502,7 +502,12 @@ static unsigned int compute_mic(schc_fragmentation_t *conn, uint8_t last_tile_pa
 	uint16_t padded_length = ((conn->bit_arr->bit_len + last_tile_padding + extra_padding) / 8);
 
 	while (i < padded_length) {
-		byte = conn->bit_arr->ptr[i];
+		if (i < conn->bit_arr->len) {
+			byte = conn->bit_arr->ptr[i];
+		}
+		else {
+			byte = 0U;
+		}
 		crc = crc ^ byte;
 		for (j = 7; j >= 0; j--) {    // do eight times.
 			mask = -(crc & 1);


### PR DESCRIPTION
Fixes

- a buffer overflow in the MIC calculation (used potentially not allocated space after bit_arr->ptr as pseudo-padding)
- a rounding error in padding calculation (when the padding is 8, it is not necessary to append that full byte and will lead to erroneous behavior on reassembly, i.e., one extra byte in the reassembled frame)
- to use byte length of a bit-array as basis for padding calculation (see commit message for further explanation)