### PR TITLE
fragmenter: add dynamic memory management for internal conn-allocation

### DIFF
--- a/examples/fragment.c
+++ b/examples/fragment.c
@@ -293,7 +293,7 @@ void init() {
 	}
 
 	/* initialize fragmenter for the constrained device */
-	schc_fragmenter_init(&tx_conn, &tx_send_callback, &end_rx, &remove_timer_entry);
+	schc_fragmenter_init(&tx_conn);
 	
 	/* initialize fragmenter for ngw */
 	tx_conn_nwgw.send 					= &rx_send_callback;

--- a/fragmenter.h
+++ b/fragmenter.h
@@ -151,10 +151,7 @@ struct schc_fragmentation_t {
 	uint8_t rule_id[4];
 };
 
-int8_t schc_fragmenter_init(schc_fragmentation_t* tx_conn,
-		uint8_t (*send)(uint8_t* data, uint16_t length, uint32_t device_id),
-		void (*end_rx)(schc_fragmentation_t* conn),
-		void (*remove_timer_entry)(schc_fragmentation_t* conn));
+int8_t schc_fragmenter_init(schc_fragmentation_t* tx_conn);
 int8_t schc_fragment(schc_fragmentation_t *tx_conn);
 int8_t schc_reassemble(schc_fragmentation_t* rx_conn);
 void schc_reset(schc_fragmentation_t* conn);
@@ -163,7 +160,7 @@ schc_fragmentation_t* schc_input(uint8_t* data, uint16_t len,
 		schc_fragmentation_t* rx_conn, uint32_t device_id);
 void schc_ack_input(uint8_t* data, schc_fragmentation_t* tx_conn);
 schc_fragmentation_t* schc_fragment_input(uint8_t* data, uint16_t len,
-		uint32_t device_id);
+		schc_fragmentation_t *tx_conn, uint32_t device_id);
 schc_fragmentation_t* schc_get_connection(uint32_t device_id);
 
 struct schc_fragmentation_rule_t* get_fragmentation_rule_by_reliability_mode(reliability_mode mode,

--- a/fragmenter.h
+++ b/fragmenter.h
@@ -57,8 +57,6 @@ typedef enum {
 } rx_state;
 
 typedef struct schc_mbuf_t {
-	/* the selected slot */
-	uint32_t slot;
 	/* start of memory block */
 	uint8_t* ptr;
 	/* length of the fragment */
@@ -88,7 +86,12 @@ typedef struct schc_fragmentation_ack_t {
 
 } schc_fragmentation_ack_t;
 
-typedef struct schc_fragmentation_t {
+typedef struct schc_fragmentation_t schc_fragmentation_t;
+
+struct schc_fragmentation_t {
+#if DYNAMIC_MEMORY
+	schc_fragmentation_t *next;
+#endif
 	/* the device id of the connection */
 	uint32_t device_id;
 	/* a pointer to the start of the unfragmented, compressed packet in a bit array */
@@ -146,7 +149,7 @@ typedef struct schc_fragmentation_t {
 	struct schc_fragmentation_rule_t* fragmentation_rule;
 	/* the rule id */
 	uint8_t rule_id[4];
-} schc_fragmentation_t;
+};
 
 int8_t schc_fragmenter_init(schc_fragmentation_t* tx_conn,
 		uint8_t (*send)(uint8_t* data, uint16_t length, uint32_t device_id),


### PR DESCRIPTION
Required for my [python wrapper](https://github.com/anr-bmbf-pivot/pylibschc).