### PR TITLE
fragmenter: unset conn->timer_ctx after free_conn_cb

### DIFF
--- a/fragmenter.c
+++ b/fragmenter.c
@@ -784,7 +784,6 @@ void schc_reset(schc_fragmentation_t* conn) {
 	conn->RX_STATE = RECV_WINDOW;
 	conn->window = 0;
 	conn->window_cnt = 0;
-	conn->timer_ctx = NULL;
 	conn->timer_flag = 0;
 	conn->input = 0;
 	memset(conn->mic, 0, MIC_SIZE_BYTES);
@@ -1375,6 +1374,7 @@ static void schc_free_connection(schc_fragmentation_t *conn)
 	}
 	schc_fragmentation_t *ptr = schc_rx_conns, *last = NULL;
 
+	conn->timer_ctx = NULL;
 	DEBUG_PRINTF("schc_free_connection(): trying to free %p\n", (void *)conn);
 	while (ptr) {
 		if (ptr == conn) {
@@ -1393,7 +1393,7 @@ static void schc_free_connection(schc_fragmentation_t *conn)
 		ptr = ptr->next;
 	}
 #else
-	(void)conn;
+	conn->timer_ctx = NULL;
 #endif
 }
 


### PR DESCRIPTION
As currently implemented, the new `free_conn_cb` is of little use, as the application context is already zeroed out beforehand. This moves that action to after the call to `free_conn_cb`.