### PR TITLE
fragmenter.c: drop unused variable

### DIFF
--- a/fragmenter.c
+++ b/fragmenter.c
@@ -130,7 +130,7 @@ static uint8_t get_fragmentation_header_length(schc_mbuf_t *mbuf, schc_fragmenta
  *
  */
 static void mbuf_print(schc_mbuf_t *head) {
-	uint8_t i = 0; uint8_t j;
+	uint8_t j;
 	schc_mbuf_t *curr = head;
 	while (curr != NULL) {
 		DEBUG_PRINTF("%d: %p\n", curr->frag_cnt, curr->ptr);
@@ -139,7 +139,6 @@ static void mbuf_print(schc_mbuf_t *head) {
 		}
 		DEBUG_PRINTF("\n");
 		curr = curr->next;
-		i++;
 	}
 }
 


### PR DESCRIPTION
LLVM is very unhappy about the unused variable to the point that it even refuses to compile the code, unless magic CFLAGS are passed. This drops the unused variable and the need of convincing LLVM to compile the code by disabling static analyzers.